### PR TITLE
unified user manifest

### DIFF
--- a/tasks/miniforge.yaml
+++ b/tasks/miniforge.yaml
@@ -75,7 +75,9 @@
         mode: "0600"
 
 - name: "Deploy manifest files for user: {{ user.name }}"
-  when: "user.mamba_envs is defined"
+  when:
+    - "manifest_dir is defined"
+    - "user.mamba_envs is defined"
   loop: "{{ user.mamba_envs }}"
   become: true
   become_user: "{{ user.name }}"


### PR DESCRIPTION
- **Accept a single list variable instead of user and manifest mapping files**
- **Check that `manifest_dir` exists before attempting to deploy manifests**
